### PR TITLE
Support Vector Drawable on XML layout

### DIFF
--- a/app/src/main/java/com/sergivonavi/materialbanner/app/MainActivity.java
+++ b/app/src/main/java/com/sergivonavi/materialbanner/app/MainActivity.java
@@ -15,8 +15,13 @@ import com.sergivonavi.materialbanner.app.activities.StyledBannerActivity;
 import com.sergivonavi.materialbanner.app.activities.WithPaddingActivity;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatDelegate;
 
 public class MainActivity extends AppCompatActivity implements View.OnClickListener {
+
+    static {
+        AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/library/src/main/java/com/sergivonavi/materialbanner/Banner.java
+++ b/library/src/main/java/com/sergivonavi/materialbanner/Banner.java
@@ -267,7 +267,7 @@ public class Banner extends ViewGroup implements BannerInterface {
                 R.style.Widget_Material_Banner);
 
         if (a.hasValue(R.styleable.Banner_icon)) {
-            setIcon(a.getDrawable(R.styleable.Banner_icon));
+            setIcon(a.getResourceId(R.styleable.Banner_icon, -1));
         }
         if (a.hasValue(R.styleable.Banner_iconTint)) {
             setIconTintColorInternal(a.getColor(R.styleable.Banner_iconTint, Color.BLACK));


### PR DESCRIPTION
If you try to use some vector drawable in XML layout the banner cause a crash on older devices (issue #5).

I have tested with Android 4.2 (API 17) and the sample app. On clicking _Banner from layout_ the app crashing.

This PR fix them by loading the drawable by ID and the existing context compat logic.